### PR TITLE
Prepare for Alpine 3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM alpine:edge
-
-# This image uses the 'edge' version of Alpine Linux, as
-# LAPACK or OpenBLAS are not available for now-stable v3.4.
+FROM alpine:latest
 
 RUN apk add --no-cache \
         bash \


### PR DESCRIPTION
Replace `alpine:edge` by `alpine:latest` once Alpine 3.5.0 is released.
