### PR TITLE
Fortran CI image: Move from edge to stable

### DIFF
--- a/fortran/Dockerfile
+++ b/fortran/Dockerfile
@@ -1,7 +1,4 @@
-FROM alpine:edge
-
-# This image uses the 'edge' version of Alpine Linux, as
-# LAPACK or OpenBLAS are not available for now-stable v3.4.
+FROM alpine:3.5
 
 RUN apk add --no-cache \
         bash \


### PR DESCRIPTION
To be merged once Alpine Linux 3.5 is released, and the corresponding official Docker base image exists!